### PR TITLE
Automatic retrieval of version numbers

### DIFF
--- a/src/MAGEMinApp.jl
+++ b/src/MAGEMinApp.jl
@@ -51,7 +51,15 @@ include(joinpath(pkg_dir,"src","Boundaries/purge.jl"))
 include(joinpath(pkg_dir,"src","Boundaries/utils.jl"))
 
 
-const GUI_version = "0.6.0"   
+const GUI_version = string(pkgversion(MAGEMinApp))
+
+# retrieve MAGEMin version number info
+data = Initialize_MAGEMin("ig", verbose=false);
+data = use_predefined_bulk_rock(data, 0);
+out  = point_wise_minimization(8.0,1000.0, data);
+
+const MAGEMin_version =out.MAGEMin_ver
+
 """
     App(; host = HTTP.Sockets.localhost, port = 8050, max_num_user=10, debug=false)
 

--- a/src/MAGEMinApp.jl
+++ b/src/MAGEMinApp.jl
@@ -51,6 +51,7 @@ include(joinpath(pkg_dir,"src","Boundaries/purge.jl"))
 include(joinpath(pkg_dir,"src","Boundaries/utils.jl"))
 
 
+const GUI_version = "0.6.0"   
 """
     App(; host = HTTP.Sockets.localhost, port = 8050, max_num_user=10, debug=false)
 
@@ -59,7 +60,6 @@ Starts the MAGEMin App.
 function App(; host = HTTP.Sockets.localhost, port = 8050, max_num_user=10, debug=false)
     message     = fetch_message()
     message2    = fetch_message2()
-    GUI_version = "0.6.0"   
     cur_dir     = pwd()                 # directory from where you started the GUI
     pkg_dir     = pkgdir(MAGEMinApp)   # package dir
     

--- a/src/PhaseDiagram_functions.jl
+++ b/src/PhaseDiagram_functions.jl
@@ -346,7 +346,7 @@ function get_phase_diagram_information(npoints, dtb,diagType,solver,bulk_L, bulk
     db_in     = retrieve_solution_phase_information(dtb)
 
 
-    PD_infos[1]  = "Phase Diagram computed using MAGEMin v$(string(pkgversion(MAGEMin_C)))  (GUI $(GUI_version)  ) <br>"
+    PD_infos[1]  = "Phase Diagram computed using MAGEMin $(MAGEMin_version) (MAGEMin_C v$(string(pkgversion(MAGEMin_C))); GUI $(GUI_version)) <br>"
     PD_infos[1] *= "‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾<br>"
     PD_infos[1] *= "Number of points <br>"
     

--- a/src/PhaseDiagram_functions.jl
+++ b/src/PhaseDiagram_functions.jl
@@ -346,7 +346,7 @@ function get_phase_diagram_information(npoints, dtb,diagType,solver,bulk_L, bulk
     db_in     = retrieve_solution_phase_information(dtb)
 
 
-    PD_infos[1]  = "Phase Diagram computed using MAGEMin v"*Out_XY[1].MAGEMin_ver*" (GUI v0.6.0) <br>"
+    PD_infos[1]  = "Phase Diagram computed using MAGEMin v$(string(pkgversion(MAGEMin_C)))  (GUI $(GUI_version)  ) <br>"
     PD_infos[1] *= "‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾<br>"
     PD_infos[1] *= "Number of points <br>"
     


### PR DESCRIPTION
We now automatically retrieve version numbers of `MAGEMin`, `MAGEMin_C` and `MAGEMinApp` and display that below the diagram; helps debugging if `MAGEMin_C` is out of whack with the latest version.
Note that the `MAGEMin` version should still correctly be coded up (seems to be behind by one version number, currently)