### PR TITLE
MAGEMinApp v0.6.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MAGEMinApp"
 uuid = "3bfd43b6-b983-4998-9dd6-d5d715d830b7"
 authors = ["Nicolas Riel <nriel@uni-mainz.de>", "Boris Kaus <kaus@uni-mainz.de>"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Tab_Simulation_Callbacks.jl
+++ b/src/Tab_Simulation_Callbacks.jl
@@ -341,10 +341,11 @@ function Tab_Simulation_Callbacks(app)
         end
 
         if ph == "ss"
-            db_in          = retrieve_solution_phase_information(dtb)
+            db_in           = retrieve_solution_phase_information(dtb)
+            id              = get_ss_from_mineral(dtb, id, aug)
 
             if id in db_in.ss_name
-                id = get_ss_from_mineral(dtb, id, aug)
+                # id = get_ss_from_mineral(dtb, id, aug)
             else
                 id = db_in.ss_name[1]
             end


### PR DESCRIPTION
- Corrected issue that was leading to not being able to display isopleths of endmember fraction for renamed solid solution  (e.g., pat from mu, or cm for spl etc.)